### PR TITLE
check and fix some pep8 and PyLint violations

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,6 @@ Then all you have to do is clone this repo and invoke vagrant:
     git clone https://github.com/wishlists/wishlists
     cd wishlists
     vagrant up
-    vagrant ssh
-    cd /vagrant
-    FLASK_APP=service:app flask run -h 0.0.0.0
-    
-### In case you already have a Vagrant VM
-    vagrant up
     vagrant provision
     vagrant ssh
     cd /vagrant
@@ -73,6 +67,7 @@ You can also manually run `nosetests` with `coverage` (but `setup.cfg` does this
 ## Running Pylint to check PEP8
 ```
 vagrant up
+vagrant provision
 vagrant ssh
 cd /vagrant
 pylint --rcfile=pylint.conf service/*.py

--- a/pylint.conf
+++ b/pylint.conf
@@ -61,6 +61,17 @@ confidence=
 # no Warning level messages displayed, use "--disable=all --enable=classes
 # --disable=W".
 disable=E1101,
+        C0115,
+        C0413,
+        R0401,
+        R0801,
+        R0903,
+        R0904,
+        W0201,
+        W0603,
+        W0612,
+        W0107,
+        W0102,
         print-statement,
         parameter-unpacking,
         unpacking-in-except,

--- a/pylint.conf
+++ b/pylint.conf
@@ -61,17 +61,6 @@ confidence=
 # no Warning level messages displayed, use "--disable=all --enable=classes
 # --disable=W".
 disable=E1101,
-        C0115,
-        C0413,
-        R0401,
-        R0801,
-        R0903,
-        R0904,
-        W0201,
-        W0603,
-        W0612,
-        W0107,
-        W0102,
         print-statement,
         parameter-unpacking,
         unpacking-in-except,

--- a/service/service.py
+++ b/service/service.py
@@ -148,10 +148,6 @@ def list_wishlists():
             abort(400, "The user_id should be an integer")
         wishlists = Wishlist.find_by_user_id(user_id)
     elif name:
-        try:
-            name = str(name)
-        except ValueError:
-            abort(400, "The name should be a string")
         wishlists = Wishlist.find_by_name(name)
     else:
         wishlists = Wishlist.all()

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -10,6 +10,7 @@ class WishlistFactory(factory.Factory):
     """ Creates fake wishlist that you don't have to feed """
 
     class Meta:
+        """ Class that defines meta data """
         model = Wishlist
 
     id = factory.Sequence(lambda n: n)
@@ -21,6 +22,7 @@ class ItemFactory(factory.Factory):
     """ Creates fake item that you don't have to feed """
 
     class Meta:
+        """ Class that defines meta data """
         model = Item
 
     id = factory.Sequence(lambda n: n)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,5 +1,13 @@
 # Created by gupta at 10-10-2020
 
+"""
+Wishlist and Item Model Test Suite
+Test cases can be run with the following:
+  nosetests -v --with-spec --spec-color
+  coverage report -m
+  codecov --token=$CODECOV_TOKEN
+"""
+
 import unittest
 import logging
 import os
@@ -48,7 +56,6 @@ class TestModel(unittest.TestCase):
 #  H E L P E R   M E T H O D S
 ######################################################################
 
-
     def _create_wishlist(self, items=[]):
         """ Creates an account from a Factory """
         fake_wishlist = WishlistFactory()
@@ -76,7 +83,6 @@ class TestModel(unittest.TestCase):
 ######################################################################
 #  T E S T   C A S E S
 ######################################################################
-
 
     def test_create_a_wishlist(self):
         """ Create a wishlist and assert that it exists """
@@ -158,7 +164,7 @@ class TestModel(unittest.TestCase):
         # Fetch it back by name
         same_wishlist = Wishlist.find_by_name(wishlist.name)[0]
         self.assertEqual(same_wishlist.id, wishlist.id)
-        self.assertEqual(same_wishlist.name, wishlist.name) 
+        self.assertEqual(same_wishlist.name, wishlist.name)
 
     def test_find_by_user_id(self):
         """ Find by user id"""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -56,8 +56,10 @@ class TestModel(unittest.TestCase):
 #  H E L P E R   M E T H O D S
 ######################################################################
 
-    def _create_wishlist(self, items=[]):
+    def _create_wishlist(self, items=None):
         """ Creates an account from a Factory """
+        if not items:
+            items = []
         fake_wishlist = WishlistFactory()
         wishlist = Wishlist(
             name=fake_wishlist.name,

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -287,7 +287,7 @@ class TestWishlistService(unittest.TestCase):
     def test_get_item_not_found(self):
         """ Test get_item if item is not found """
 
-        wishlist, items = self._create_items(1)
+        wishlist = self._create_items(1)[0]
         resp = self.app.get(
             "/wishlists/{}/items/{}".format(wishlist.id, 55000),
             content_type="application/json"

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -214,7 +214,7 @@ class TestWishlistService(unittest.TestCase):
                           ' body of request contained bad or no data'))
 
     def test_create_wishlist_with_unsupported_media_type(self):
-        """ Test the wishlist add request has unsupported media type """
+        """ Test the wishlist add request with unsupported media type """
         test_wishlist = {
             "name": "wishlist1",
             "user_id": 1,

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -172,6 +172,7 @@ class TestWishlistService(unittest.TestCase):
         self.assertEqual(same_wishlist["user_id"], wishlist.user_id)
 
     def test_get_wishlist_list_by_user_id_wrong_data_type(self):
+        """ Test the case that a wrong data type of user_id is used """
         resp = self.app.get("/wishlists?user_id=\"1\"")
         self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -197,6 +198,7 @@ class TestWishlistService(unittest.TestCase):
                                            " Wishlist '0' was not found."))
 
     def test_create_wishlist_with_missing_args(self):
+        """ Test the wishlist added has missing arguments """
         test_wishlist = {
             "name": "wishlist1",
             "user_id": 1
@@ -212,6 +214,7 @@ class TestWishlistService(unittest.TestCase):
                           ' body of request contained bad or no data'))
 
     def test_create_wishlist_with_unsupported_media_type(self):
+        """ Test the wishlist add request has unsupported media type """
         test_wishlist = {
             "name": "wishlist1",
             "user_id": 1,
@@ -359,7 +362,7 @@ class TestWishlistService(unittest.TestCase):
 
     @patch('service.service.Wishlist')
     def test_method_not_allowed(self, method_not_allowed_mock):
-        """ Test a METHOD_NOT_ALLOWED error from Find By Name """
+        """ Test 405_METHOD_NOT_ALLOWED error"""
         method_not_allowed_mock.side_effect = DataValidationError()
         test_wishlist = WishlistFactory()
         resp = self.app.put(
@@ -379,7 +382,7 @@ class TestWishlistService(unittest.TestCase):
         resp = self.app.get('/wishlists/500')
         self.assertEqual(resp.status_code,
                          status.HTTP_500_INTERNAL_SERVER_ERROR)
-        
+
     def test_delete_wishlist(self):
         """ Delete a non-existing Wishlist """
         test_wishlist = WishlistFactory()


### PR DESCRIPTION
1. Fix some pep8 and PyLint violations. The score has reached the required 9/10.
2. Remove the data type check of the variable ``` name ``` in LIST API.
3. Update README.md file by adding ``` vagrant provision ``` to the prerequisites.
