### PR TITLE
update DELETE button to clear search results after deleting a wishlist

### DIFF
--- a/service/static/js/rest_api.js
+++ b/service/static/js/rest_api.js
@@ -160,6 +160,8 @@ $(function () {
 
         ajax.done(function(res){
             clear_wishlist_form_data()
+            $("#search_results").empty();
+            $("#search_results_items").empty();
             flash_message("Wishlist has been deleted")
         });
 


### PR DESCRIPTION
1. update DELETE button to clear search results after deleting a wishlist
<img width="959" alt="Screen Shot 2020-11-16 at 11 11 20 AM" src="https://user-images.githubusercontent.com/12811833/99277969-7bf7a080-27fc-11eb-867e-5f2d50ebf837.png">
